### PR TITLE
feature/MAPS-715-add-automated-flag-to-payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Basically a roadmap.
 - filter workloads - ✓
 - scroll over workload's versions - ✓
 - readonly mode - ✓
-- turn on/off flux automation on a workload
+- turn on/off flux automation on a workload - ✓
 - features you'd like to see?
 
 ### Maybe in the future, if people want it

--- a/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
+++ b/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
@@ -7,6 +7,7 @@
       label="automated"
       track-by="automated"
       :allow-empty="false"
+      :disabled="isDisabled"
       deselect-label="Can't remove this value"
       @input="valueChanged"
     >
@@ -47,11 +48,25 @@ export default class WorkloadAvailableAutomatedFlag extends Vue {
   @Prop() protected workload: any;
 
   protected value: any = null;
+  protected isDisabled: Boolean = false;
 
   protected possibleOptions: any = [
     { automated: true },
     { automated: false },
   ];
+
+  public updated() {
+    this.refreshSelectedValue();
+  }
+
+  public refreshSelectedValue() {
+    console.dir(this.workload);
+    if (this.workload.selected_tag.tag && this.workload.selected_tag.tag != this.workload.available_tags[0].tag) {
+      this.isDisabled = true;
+    } else {
+      this.isDisabled = false;
+    }
+  }
 
   get options() {
     return this.possibleOptions;

--- a/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
+++ b/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="available-automated-flag-select-wrapper">
+    <multiselect
+      v-model="value"
+      :options="options"
+      :placeholder="currentTag ? (currentTag.automated ? 'true' : 'false') : ''"
+      label="automated"
+      track-by="automated"
+      :allow-empty="false"
+      deselect-label="Can't remove this value"
+      @input="valueChanged"
+    >
+      <template slot="singleLabel" slot-scope="{ option }">
+        <strong>{{ option.automated }}</strong>
+      </template>
+      <template slot="option" slot-scope="props">
+        <div class="option__desc">
+          <span>{{ props.option.automated }}</span>
+        </div>
+      </template>
+    </multiselect>
+  </div>
+</template>
+
+<style lang="scss">
+@import "../../assets/scss/include";
+.available-automated-flag-select-wrapper {
+  min-width: max-content;
+  .multiselect__content-wrapper {
+    min-width: max-content;
+    right: 0;
+  }
+}
+</style>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import Multiselect from "vue-multiselect";
+
+@Component({
+  components: {
+    Multiselect
+  }
+})
+export default class WorkloadAvailableAutomatedFlag extends Vue {
+  @Prop() protected currentTag: any;
+  @Prop() protected workload: any;
+
+  protected value: any = null;
+
+  protected possibleOptions: any = [
+    { automated: true },
+    { automated: false },
+  ];
+
+  get options() {
+    return this.possibleOptions;
+  }
+
+  public valueChanged() {
+    this.$emit("input", this.workload, this.value);
+  }
+}
+</script>

--- a/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
+++ b/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
@@ -7,7 +7,7 @@
       label="automated"
       track-by="automated"
       :allow-empty="false"
-      :disabled="isDisabled"
+      :disabled="(workload.selected_tag.tag) ? isDisabled : currentTag.tag != workload.available_tags[0].tag"
       deselect-label="Can't remove this value"
       @input="valueChanged"
     >
@@ -48,7 +48,7 @@ export default class WorkloadAvailableAutomatedFlag extends Vue {
   @Prop() protected workload: any;
 
   protected value: any = null;
-  protected isDisabled: Boolean = false;
+  protected isDisabled: Boolean = true;
 
   protected possibleOptions: any = [
     { automated: true },

--- a/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
+++ b/frontend/components/Workloads/WorkloadAvailableAutomatedFlag.vue
@@ -60,12 +60,8 @@ export default class WorkloadAvailableAutomatedFlag extends Vue {
   }
 
   public refreshSelectedValue() {
-    console.dir(this.workload);
-    if (this.workload.selected_tag.tag && this.workload.selected_tag.tag != this.workload.available_tags[0].tag) {
-      this.isDisabled = true;
-    } else {
-      this.isDisabled = false;
-    }
+    const {selected_tag, available_tags} = this.workload;
+    this.isDisabled = (selected_tag.tag && selected_tag.tag != available_tags[0].tag) ? true : false;
   }
 
   get options() {

--- a/frontend/components/Workloads/WorkloadAvailableTags.vue
+++ b/frontend/components/Workloads/WorkloadAvailableTags.vue
@@ -77,10 +77,7 @@ export default class WorkloadAvailableTags extends Vue {
   }
 
   get options() {
-    return this.optionsProp.map((option: any) => {
-      option.$isDisabled = option.current;
-      return option;
-    });
+    return this.optionsProp;
   }
 
   public valueChanged() {

--- a/frontend/components/Workloads/WorkloadAvailableTags.vue
+++ b/frontend/components/Workloads/WorkloadAvailableTags.vue
@@ -3,7 +3,7 @@
     <multiselect
       v-model="value"
       :options="options"
-      :placeholder="currentTag ? (currentTag.tag + (currentTag.automated ? ' (Auto Update)' : '')) : 'Select tag'"
+      :placeholder="currentTag ? currentTag.tag : 'Select tag'"
       label="tag"
       track-by="tag"
       :allow-empty="false"
@@ -16,7 +16,6 @@
       <template slot="option" slot-scope="props">
         <div class="option__desc">
           <span class="option__tag">{{ props.option.tag }}</span>
-          <span>{{ props.option.automated ? '(Auto Update)' : ''}}</span>
           <span class="option__date">
             <strong>{{ moment(props.option.date).fromNow() }}</strong>
           </span>

--- a/frontend/components/Workloads/WorkloadRelease.vue
+++ b/frontend/components/Workloads/WorkloadRelease.vue
@@ -34,6 +34,7 @@ export default class WorkloadRelease extends Vue {
       Current: workload.image + ":" + workload.current_tag.tag,
       Target: workload.image + ":" + workload.selected_tag.tag,
       Automated: workload.selected_tag.automated,
+      Namespace: workload.selected_tag.namespace,
     };
 
     this.releaseVersion({ workload: this.workload, releaseData });

--- a/frontend/components/Workloads/WorkloadRelease.vue
+++ b/frontend/components/Workloads/WorkloadRelease.vue
@@ -33,7 +33,7 @@ export default class WorkloadRelease extends Vue {
       Container: workload.container,
       Current: workload.image + ":" + workload.current_tag.tag,
       Target: workload.image + ":" + workload.selected_tag.tag,
-      Automated: workload.automated
+      Automated: workload.selected_tag.automated,
     };
 
     this.releaseVersion({ workload: this.workload, releaseData });

--- a/frontend/components/Workloads/WorkloadsList.vue
+++ b/frontend/components/Workloads/WorkloadsList.vue
@@ -19,6 +19,12 @@
           @input="tagChanged"
           v-else-if="props.column.field == 'available_tags'"
         />
+        <workload-available-automated-flag
+          :current-tag="props.row.current_tag"
+          :workload="props.row"
+          v-else-if="props.column.field == 'automated'"
+          @input="automatedChanged"
+        />
         <span v-else>{{props.formattedRow[props.column.field]}}</span>
       </template>
     </vue-good-table>
@@ -29,6 +35,7 @@
 import { Component, Vue, Watch } from "vue-property-decorator";
 import { StoreNamespaces } from "../../store/types/StoreNamespaces";
 import WorkloadAvailableTags from "./WorkloadAvailableTags.vue";
+import WorkloadAvailableAutomatedFlag from "./WorkloadAvailableAutomatedFlag.vue";
 import WorkloadRelease from "./WorkloadRelease.vue";
 import NamespaceSelect from "./NamespaceSelect.vue";
 import WorkloadStatus from "./WorkloadStatus.vue";
@@ -40,6 +47,7 @@ import { Tag } from "../../store/types/Workloads/Tag";
 @Component({
   components: {
     WorkloadAvailableTags,
+    WorkloadAvailableAutomatedFlag,
     NamespaceSelect,
     WorkloadRelease,
     WorkloadStatus
@@ -70,6 +78,10 @@ export default class WorkloadsList extends Vue {
     {
       label: "Available tags",
       field: "available_tags"
+    },
+    {
+      label: "Automated Update",
+      field: "automated"
     }
   ];
 
@@ -90,6 +102,9 @@ export default class WorkloadsList extends Vue {
   @Action("updateSelectedTag", { namespace: StoreNamespaces.workloads })
   public updateSelectedTag: any;
 
+  @Action("updateAutomatedFlag", { namespace: StoreNamespaces.workloads })
+  public updateAutomatedFlag: any;
+
   public created() {
     if (this.$env.READ_ONLY != "true") {
       this.columns.push({
@@ -101,6 +116,10 @@ export default class WorkloadsList extends Vue {
 
   public tagChanged(workload: Workload, tag: Tag) {
     this.updateSelectedTag({ workload, tag });
+  }
+
+  public automatedChanged(workload: Workload, automatedFlag: any) {
+    this.updateAutomatedFlag({ workload, automatedFlag });
   }
 }
 </script>

--- a/frontend/store/types/Workloads/Tag.ts
+++ b/frontend/store/types/Workloads/Tag.ts
@@ -3,4 +3,5 @@ export interface Tag {
     date: string;
     current: boolean;
     automated: boolean;
+    namespace: string;
 }

--- a/frontend/store/workloads/actions.ts
+++ b/frontend/store/workloads/actions.ts
@@ -35,7 +35,7 @@ export const actions: ActionTree<WorkloadsState, RootState> = {
     releaseVersion: ({dispatch}, {workload, releaseData}): any => {
         dispatch('updateWorkloadStatus', {workload, status: WorkloadStatuses.releasing})
         axios.post('/release', releaseData).then(
-            ()  => console.log('/release done!'),
+            ()  => console.log('/release request sended!'),
         );
     },
 };

--- a/frontend/store/workloads/actions.ts
+++ b/frontend/store/workloads/actions.ts
@@ -25,6 +25,7 @@ export const actions: ActionTree<WorkloadsState, RootState> = {
         })
     },
     updateSelectedTag:  ({commit}, payload) => commit('UPDATE_SELECTED_TAG', payload),
+    updateAutomatedFlag:  ({commit}, payload) => commit('UPDATE_AUTOMATED_FLAG', payload),
     fetchWorkloads: ({commit}, namespace: string): any => axios.get('/workloads/' + namespace).then(
         (response: any) => {
             const workloads = workloadsTransformer(response.data);

--- a/frontend/store/workloads/actions.ts
+++ b/frontend/store/workloads/actions.ts
@@ -33,8 +33,9 @@ export const actions: ActionTree<WorkloadsState, RootState> = {
         },
     ),
     releaseVersion: ({dispatch}, {workload, releaseData}): any => {
+        dispatch('updateWorkloadStatus', {workload, status: WorkloadStatuses.releasing})
         axios.post('/release', releaseData).then(
-            ()  => dispatch('updateWorkloadStatus', {workload, status: WorkloadStatuses.releasing}),
+            ()  => console.log('/release done!'),
         );
     },
 };

--- a/frontend/store/workloads/mutations.ts
+++ b/frontend/store/workloads/mutations.ts
@@ -12,6 +12,19 @@ export const mutations: MutationTree<WorkloadsState> = {
         }
         w.selected_tag = tag;
     },
+    UPDATE_AUTOMATED_FLAG: (state: WorkloadsState, {workload, automatedFlag}) =>  {
+        const w = state.workloads.find((w: Workload) => (workload.id == w.id && w.container == workload.container));
+        if (!w) {
+            throw new Error(`Unable to update workload, workload (${workload.id}) not found`);
+        }
+
+        if (w.selected_tag.tag) {
+            w.selected_tag.automated = automatedFlag.automated;
+        } else {
+            w.selected_tag = w.current_tag;
+            w.selected_tag.automated = automatedFlag.automated;
+        }
+    },
     UPDATE_WORKLOAD_STATUS: (state: WorkloadsState, {workload, status}) => {
         const workloadInst = state.workloads.find((w) => w.id == workload.id && w.container == workload.container);
         if (!workloadInst) {

--- a/frontend/store/workloads/transformers.ts
+++ b/frontend/store/workloads/transformers.ts
@@ -35,8 +35,6 @@ export const workloadsTransformer = (workloads: any[]) => {
             current.Automated = workload.Automated
             const currentNamespace = parseNamespace(workload.ID);
 
-            console.dir(parseNamespace(workload.ID));
-
             let availableTagList = []
             if (container.Available) {
 

--- a/frontend/store/workloads/transformers.ts
+++ b/frontend/store/workloads/transformers.ts
@@ -48,7 +48,7 @@ export const workloadsTransformer = (workloads: any[]) => {
             }
             const availableTags = availableTagList
 
-            const isStatusUpToDate = (availableTags: Tag[], currentTag: string) => currentTag == 'latest' || ( availableTags.length && currentTag == availableTags[0].tag && current.Automated == availableTags[0].automated)
+            const isStatusUpToDate = (availableTags: Tag[], currentTag: string) => currentTag == 'latest' || ( availableTags.length && currentTag == availableTags[0].tag)
 
             const temp = {
                 id: workload.ID,

--- a/frontend/store/workloads/transformers.ts
+++ b/frontend/store/workloads/transformers.ts
@@ -45,19 +45,6 @@ export const workloadsTransformer = (workloads: any[]) => {
                         automated: (availableTag === currentTag) ? current.Automated : false,
                     };
                 })
-                
-                /**
-                 * The latest workload will get a clone, based on the current active payload.
-                 * This enables us to distinguish whether we want to deploy the latest state with automated true or automated false.
-                 * Latest with automated true should always be on top of the selection.
-                 */
-                if (container.Name === "chart-image") {
-                    let availableTag = JSON.parse(JSON.stringify(availableTagList[0]));
-                    availableTag.current = false;
-                    availableTag.automated = !availableTag.automated;
-                    (availableTag.automated) ? availableTagList.splice(0, 0, availableTag) : availableTagList.splice(1, 0, availableTag);
-                }
-
             }
             const availableTags = availableTagList
 

--- a/frontend/store/workloads/transformers.ts
+++ b/frontend/store/workloads/transformers.ts
@@ -1,5 +1,6 @@
 import { WorkloadStatuses } from '../types/Workloads/WorkloadStatuses';
 import { Tag } from '../types/Workloads/Tag';
+import { NamespacesState } from '../types/Namespaces/NamespacesState';
 
 function getImageFromUrl(url: any) {
     url = url.split(':');
@@ -12,6 +13,11 @@ function getImageFromUrl(url: any) {
 function parseCurrentTag(currentTag: string): string {
     const tagParts = currentTag.split(':');
     return tagParts.length == 1 ? 'latest' : (tagParts.pop() || 'unknown')
+}
+
+function parseNamespace(currentTag: string): string {
+    const tagParts = currentTag.split(':');
+    return tagParts.length == 1 ? '' : (tagParts[0] || 'unknown')
 }
 
 export const workloadsTransformer = (workloads: any[]) => {
@@ -27,6 +33,9 @@ export const workloadsTransformer = (workloads: any[]) => {
             const current = (container.Current.ID && container.Current) || (container.Available && container.Available[0]) || {}
             const currentTag = parseCurrentTag(current.ID)
             current.Automated = workload.Automated
+            const currentNamespace = parseNamespace(workload.ID);
+
+            console.dir(parseNamespace(workload.ID));
 
             let availableTagList = []
             if (container.Available) {
@@ -43,6 +52,7 @@ export const workloadsTransformer = (workloads: any[]) => {
                         date: available.CreatedAt,
                         current: availableTag === currentTag,
                         automated: (availableTag === currentTag) ? current.Automated : false,
+                        namespace: currentNamespace,
                     };
                 })
             }
@@ -62,6 +72,7 @@ export const workloadsTransformer = (workloads: any[]) => {
                     current: true,
                     date: current.CreatedAt || null,
                     automated: current.Automated,
+                    namespace: currentNamespace,
                 },
                 selected_tag: {},
             };

--- a/frontend/store/workloads/transformers.ts
+++ b/frontend/store/workloads/transformers.ts
@@ -61,7 +61,7 @@ export const workloadsTransformer = (workloads: any[]) => {
             }
             const availableTags = availableTagList
 
-            const isStatusUpToDate = (availableTags: Tag[], currentTag: string) => currentTag == 'latest' || ( availableTags.length && currentTag == availableTags[0].tag)
+            const isStatusUpToDate = (availableTags: Tag[], currentTag: string) => currentTag == 'latest' || ( availableTags.length && currentTag == availableTags[0].tag && current.Automated == availableTags[0].automated)
 
             const temp = {
                 id: workload.ID,


### PR DESCRIPTION
Den Weg des Datenstroms innerhalb der App sichtbar zu machen, hat sich etwas schwierig gestaltet.
Dieser PR sollte aber das gewünschte Verhalten abbilden. Wir müssen noch schauen ob man am Backend/Frontend noch weitere Anpassungen machen muss.
Es gab einige widersprüchliche Status-Darstellungen im UI, könnte aber auch am lokalen Setup gelegen haben.